### PR TITLE
chore(deps): patch update dayjs to v1.11.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@rollup/plugin-typescript": "11.1.6",
         "@tsconfig/node20": "20.1.4",
         "@types/node": "20.12.7",
-        "dayjs": "1.11.9",
+        "dayjs": "1.11.11",
         "dexie": "4.0.4",
         "eslint": "8.57.0",
         "eslint-plugin-jest": "28.2.0",
@@ -3089,9 +3089,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.9",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.9.tgz",
-      "integrity": "sha512-QvzAURSbQ0pKdIye2txOzNaHmxtUBXerpY0FJsFXUMKbIZeFm5ht1LS/jFsrncjnmtv8HsG0W2g6c0zUjZWmpA==",
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.11.tgz",
+      "integrity": "sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg==",
       "dev": true
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@rollup/plugin-typescript": "11.1.6",
     "@tsconfig/node20": "20.1.4",
     "@types/node": "20.12.7",
-    "dayjs": "1.11.9",
+    "dayjs": "1.11.11",
     "dexie": "4.0.4",
     "eslint": "8.57.0",
     "eslint-plugin-jest": "28.2.0",


### PR DESCRIPTION
This PR updates these packages:

|Package|Dependency type|Level|Current version|New version|
|---|---|---|---|---|
|[dayjs](https://www.npmjs.com/package/dayjs)|devDependencies|patch|[`1.11.9`](https://www.npmjs.com/package/dayjs/v/1.11.9)|[`1.11.11`](https://www.npmjs.com/package/dayjs/v/1.11.11)|

## Package diffs

- [GitHub](https://togithub.com/iamkun/dayjs/compare/v1.11.9...v1.11.11)
- [npmfs](https://npmfs.com/compare/dayjs/1.11.9/1.11.11)
- [Package Diff](https://diff.intrinsic.com/dayjs/1.11.9/1.11.11)
- [Renovate Bot Package Diff](https://renovatebot.com/diffs/npm/dayjs/1.11.9/1.11.11)

## Release notes

- [v1.11.9](https://togithub.com/iamkun/dayjs/releases/tag/v1.11.9)
- [v1.11.10](https://togithub.com/iamkun/dayjs/releases/tag/v1.11.10)
- [v1.11.11](https://togithub.com/iamkun/dayjs/releases/tag/v1.11.11)

---
<details>
<summary>Metadata</summary>

**Don't remove or edit this section because it will be used by npm-update-package.**

<div id="npm-update-package-metadata">

```json
{
  "version": "4.0.0-2",
  "packages": [
    {
      "name": "dayjs",
      "currentVersion": "1.11.9",
      "newVersion": "1.11.11",
      "level": "patch"
    }
  ]
}
```

</div>
</details>

---
This PR has been generated by [npm-update-package](https://github.com/npm-update-package/npm-update-package) v4.0.0-2