### PR TITLE
chore(deps): patch update @types/node to v20.12.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@munierujp/eslint-config-typescript": "43.0.0",
         "@rollup/plugin-typescript": "11.1.6",
         "@tsconfig/node20": "20.1.4",
-        "@types/node": "20.12.7",
+        "@types/node": "20.12.9",
         "dayjs": "1.11.9",
         "dexie": "4.0.4",
         "eslint": "8.57.0",
@@ -1943,9 +1943,9 @@
       "peer": true
     },
     "node_modules/@types/node": {
-      "version": "20.12.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
-      "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
+      "version": "20.12.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.9.tgz",
+      "integrity": "sha512-o93r47yu04MHumPBCFg0bMPBMNgtMg3jzbhl7e68z50+BMHmRMGDJv13eBlUgOdc9i/uoJXGMGYLtJV4ReTXEg==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@munierujp/eslint-config-typescript": "43.0.0",
     "@rollup/plugin-typescript": "11.1.6",
     "@tsconfig/node20": "20.1.4",
-    "@types/node": "20.12.7",
+    "@types/node": "20.12.9",
     "dayjs": "1.11.9",
     "dexie": "4.0.4",
     "eslint": "8.57.0",


### PR DESCRIPTION
This PR updates these packages:

|Package|Dependency type|Level|Current version|New version|
|---|---|---|---|---|
|[@types/node](https://www.npmjs.com/package/@types/node)|devDependencies|patch|[`20.12.7`](https://www.npmjs.com/package/@types/node/v/20.12.7)|[`20.12.9`](https://www.npmjs.com/package/@types/node/v/20.12.9)|

## Package diffs

- [GitHub](https://togithub.com/DefinitelyTyped/DefinitelyTyped/compare/v20.12.7...v20.12.9)
- [npmfs](https://npmfs.com/compare/@types/node/20.12.7/20.12.9)
- [Package Diff](https://diff.intrinsic.com/@types/node/20.12.7/20.12.9)
- [Renovate Bot Package Diff](https://renovatebot.com/diffs/npm/@types/node/20.12.7/20.12.9)

---
<details>
<summary>Metadata</summary>

**Don't remove or edit this section because it will be used by npm-update-package.**

<div id="npm-update-package-metadata">

```json
{
  "version": "4.0.0",
  "packages": [
    {
      "name": "@types/node",
      "currentVersion": "20.12.7",
      "newVersion": "20.12.9",
      "level": "patch"
    }
  ]
}
```

</div>
</details>

---
This PR has been generated by [npm-update-package](https://github.com/npm-update-package/npm-update-package) v4.0.0