### PR TITLE
chore(deps): minor update eslint-plugin-jest to v28.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "dayjs": "1.11.9",
         "dexie": "4.0.4",
         "eslint": "8.57.0",
-        "eslint-plugin-jest": "28.2.0",
+        "eslint-plugin-jest": "28.5.0",
         "eslint-plugin-userscripts": "0.5.2",
         "glob": "10.3.12",
         "jest": "29.7.0",
@@ -2061,7 +2061,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.5.0.tgz",
       "integrity": "sha512-Z1r7uJY0MDeUlql9XJ6kRVgk/sP11sr3HKXn268HZyqL7i4cEfrdFuSSY/0tUqT37l5zT0tJOsuDP16kio85iA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "7.5.0",
         "@typescript-eslint/visitor-keys": "7.5.0"
@@ -2107,7 +2106,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.5.0.tgz",
       "integrity": "sha512-tv5B4IHeAdhR7uS4+bf8Ov3k793VEVHd45viRRkehIUZxm0WF82VPiLgHzA/Xl4TGPg1ZD49vfxBKFPecD5/mg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
       },
@@ -2121,7 +2119,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.5.0.tgz",
       "integrity": "sha512-YklQQfe0Rv2PZEueLTUffiQGKQneiIEKKnfIqPIOxgM9lKSZFCjT5Ad4VqRKj/U4+kQE3fa8YQpskViL7WjdPQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "7.5.0",
         "@typescript-eslint/visitor-keys": "7.5.0",
@@ -2150,7 +2147,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.5.0.tgz",
       "integrity": "sha512-3vZl9u0R+/FLQcpy2EHyRGNqAS/ofJ3Ji8aebilfJe+fobK8+LbIFmrHciLVDxjDoONmufDcnVSF38KwMEOjzw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
@@ -2176,7 +2172,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.5.0.tgz",
       "integrity": "sha512-mcuHM/QircmA6O7fy6nn2w/3ditQkj+SgtOc8DW3uQ10Yfj42amm2i+6F2K4YAOPNNTmE6iM1ynM6lrSwdendA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "7.5.0",
         "eslint-visitor-keys": "^3.4.1"
@@ -3760,12 +3755,12 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "28.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.2.0.tgz",
-      "integrity": "sha512-yRDti/a+f+SMSmNTiT9/M/MzXGkitl8CfzUxnpoQcTyfq8gUrXMriVcWU36W1X6BZSUoyUCJrDAWWUA2N4hE5g==",
+      "version": "28.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.5.0.tgz",
+      "integrity": "sha512-6np6DGdmNq/eBbA7HOUNV8fkfL86PYwBfwyb8n23FXgJNTR8+ot3smRHjza9LGsBBZRypK3qyF79vMjohIL8eQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/utils": "^6.0.0"
+        "@typescript-eslint/utils": "^6.0.0 || ^7.0.0"
       },
       "engines": {
         "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
@@ -3782,106 +3777,6 @@
         "jest": {
           "optional": true
         }
-      }
-    },
-    "node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
-      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
-      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
-      "dev": true,
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
-      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "minimatch": "9.0.3",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/utils": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
-      "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
-      "dev": true,
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@types/json-schema": "^7.0.12",
-        "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/typescript-estree": "6.21.0",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
-      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "eslint-visitor-keys": "^3.4.1"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/eslint-plugin-jsdoc": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dayjs": "1.11.9",
     "dexie": "4.0.4",
     "eslint": "8.57.0",
-    "eslint-plugin-jest": "28.2.0",
+    "eslint-plugin-jest": "28.5.0",
     "eslint-plugin-userscripts": "0.5.2",
     "glob": "10.3.12",
     "jest": "29.7.0",


### PR DESCRIPTION
This PR updates these packages:

|Package|Dependency type|Level|Current version|New version|
|---|---|---|---|---|
|[eslint-plugin-jest](https://www.npmjs.com/package/eslint-plugin-jest)|devDependencies|minor|[`28.2.0`](https://www.npmjs.com/package/eslint-plugin-jest/v/28.2.0)|[`28.5.0`](https://www.npmjs.com/package/eslint-plugin-jest/v/28.5.0)|

## Package diffs

- [GitHub](https://togithub.com/jest-community/eslint-plugin-jest/compare/v28.2.0...v28.5.0)
- [npmfs](https://npmfs.com/compare/eslint-plugin-jest/28.2.0/28.5.0)
- [Package Diff](https://diff.intrinsic.com/eslint-plugin-jest/28.2.0/28.5.0)
- [Renovate Bot Package Diff](https://renovatebot.com/diffs/npm/eslint-plugin-jest/28.2.0/28.5.0)

## Release notes

- [v28.2.0](https://togithub.com/jest-community/eslint-plugin-jest/releases/tag/v28.2.0)
- [v28.3.0](https://togithub.com/jest-community/eslint-plugin-jest/releases/tag/v28.3.0)
- [v28.4.0](https://togithub.com/jest-community/eslint-plugin-jest/releases/tag/v28.4.0)
- [v28.5.0](https://togithub.com/jest-community/eslint-plugin-jest/releases/tag/v28.5.0)

---
<details>
<summary>Metadata</summary>

**Don't remove or edit this section because it will be used by npm-update-package.**

<div id="npm-update-package-metadata">

```json
{
  "version": "4.0.0",
  "packages": [
    {
      "name": "eslint-plugin-jest",
      "currentVersion": "28.2.0",
      "newVersion": "28.5.0",
      "level": "minor"
    }
  ]
}
```

</div>
</details>

---
This PR has been generated by [npm-update-package](https://github.com/npm-update-package/npm-update-package) v4.0.0